### PR TITLE
Fix the Jenkins core dependency error for k8s plugin

### DIFF
--- a/formulas/k8s.yaml
+++ b/formulas/k8s.yaml
@@ -29,7 +29,7 @@ plugins:
   - groupId: "org.csanchez.jenkins.plugins"
     artifactId: "kubernetes"
     source:
-      version: "1.25.0"
+      version: "1.24.1"
   # indirect dependencies
   - groupId: "org.jenkinsci.plugins"
     artifactId: "kubernetes-credentials"


### PR DESCRIPTION
The exception stack like this:

```
java.io.IOException: Kubernetes plugin version 1.25.0 failed to load.
 - You must update Jenkins from version 2.204.5 to version 2.217 or later to run this plugin.
```

**Make sure that you've checked the boxes below before you submit PR:**

### Always

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Written well with PR title

### For new formulas

- [x] Have read through [the formulas guide](../formulas/README-zh.md)
- [x] I've tested it locally

<!--
Put an `x` into the [ ] to show you have filled the information
-->